### PR TITLE
Rename macmini runner and regen workflows.

### DIFF
--- a/.github/workflows/_benchmark.yml
+++ b/.github/workflows/_benchmark.yml
@@ -62,7 +62,7 @@ on:
         options:
         - linux-x86_64-vultr
         - linux-x86_64-linux
-        - darwin-arm64-m4pro-mac
+        - darwin-arm64-macm4pro
         - all
       benchmarks:
         description: Benchmarks to run (comma-separated; empty runs all benchmarks)
@@ -329,13 +329,13 @@ jobs:
       flags: ${{ inputs.tier2 == true && 'tier2' || '' }},${{ inputs.jit == true &&
         'jit' || '' }},${{ inputs.nogil == true && 'nogil' || '' }},${{ inputs.clang
         == true && 'clang' || '' }}
-  benchmark-darwin-arm64-m4pro-mac:
-    runs-on: [self-hosted, macos, bare-metal, darwin-arm64-m4pro-mac]
+  benchmark-darwin-arm64-macm4pro:
+    runs-on: [self-hosted, macos, bare-metal, darwin-arm64-macm4pro]
 
     steps:
     - name: Setup environment
       run: |-
-        echo "BENCHMARK_MACHINE_NICKNAME=m4pro-mac" >> $GITHUB_ENV
+        echo "BENCHMARK_MACHINE_NICKNAME=macm4pro" >> $GITHUB_ENV
     - name: Checkout benchmarking
       uses: actions/checkout@v4
     - name: git gc
@@ -426,7 +426,7 @@ jobs:
         path: |
           benchmark.json
         overwrite: true
-    if: ${{ (inputs.machine == 'darwin-arm64-m4pro-mac' || inputs.machine == 'all')
+    if: ${{ (inputs.machine == 'darwin-arm64-macm4pro' || inputs.machine == 'all')
       }}
     env:
       flags: ${{ inputs.tier2 == true && 'tier2' || '' }},${{ inputs.jit == true &&

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ on:
         options:
         - linux-x86_64-vultr
         - linux-x86_64-linux
-        - darwin-arm64-m4pro-mac
+        - darwin-arm64-macm4pro
         - all
       benchmarks:
         description: Benchmarks to run (comma-separated; empty runs all benchmarks)

--- a/bench_runner.toml
+++ b/bench_runner.toml
@@ -48,7 +48,7 @@ arch = "x86_64"
 hostname = "pyperf"
 available = true
 
-[runners.m4pro-mac]
+[runners.macm4pro]
 os = "darwin"
 arch = "arm64"
 hostname = "macmini"


### PR DESCRIPTION
Apparently runner names can't contain '-' or things will break, so rename the macmini runner.
