### PR TITLE
Add the macos results to plots.

### DIFF
--- a/bench_runner.toml
+++ b/bench_runner.toml
@@ -57,11 +57,11 @@ available = true
 [plot]
 bases = ["3.12.6", "3.13.0rc2"]
 versions = [[3, 13], [3, 14]]
-runners = ["linux", "vultr"]
-names = ["linux", "linux-vultr"]
-colors = ["C0", "C0"]
-styles = ["-", ":"]
-markers = ["s", "s"]
+runners = ["linux", "vultr", "macm4pro"]
+names = ["linux", "linux-vultr", "macos"]
+colors = ["C0", "C0", "C2"]
+styles = ["-", ":", "-"]
+markers = ["s", "s", "^"]
 
 [publish_mirror]
 skip = true


### PR DESCRIPTION
This doesn't regenerate the plots because https://github.com/faster-cpython/bench_runner/issues/377 causes a lot of spurious changes, so I'm leaving that for the next benchmarking run.