### PR TITLE
Use a specific version of bench_runner

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/faster-cpython/bench_runner@main
+bench_runner==1.6.4


### PR DESCRIPTION
Yhg1s suggested this a while ago. I think running off of main finally caught up with us, as it looks like the current main does not have one of the commands used by the workflow files in the repo (specifically, `should_run`). See https://github.com/facebookexperimental/free-threading-benchmarking/actions/runs/14414224904/job/40428161872). Pin to a known good version from PyPI.